### PR TITLE
Remove `actions/checkout` from `trial.yaml` - closes #3

### DIFF
--- a/.github/workflows/trial.yaml
+++ b/.github/workflows/trial.yaml
@@ -6,7 +6,6 @@ jobs:
   echo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           event: ${{ toJson(github.event) }}


### PR DESCRIPTION
'actions/checkout' was not needed for the action to work.