### PR TITLE
Improve message readability - resolves #1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,8 @@ inputs:
     description: The token to communicate with the messaging API
   providers:
     description: String that contains the messaging provider to use for notifications, formatted like "provider:channelID", separated by comma
+  refName:
+    description: The "github.ref_name"
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ export async function run(): Promise<void> {
     const apiToken: string = getInput("apiToken");
     const apiUrl: string = getInput("apiUrl");
     const providers: string = getInput("providers");
+    const refName: string = getInput("refName")
 
     if (!event || !apiToken || !providers || !apiUrl) {
       let error = "invalid inputs:";
@@ -34,7 +35,7 @@ export async function run(): Promise<void> {
       .map<ProviderConfig>((e) => ({ provider: e[0], channel: e[1] }));
     debug(`Provider configs: ${providerConfigs}`);
 
-    const message = generateMessage(parsedEvent);
+    const message = generateMessage(parsedEvent, refName);
     debug(`Message: ${message}`);
 
     await sendRequest(message, providerConfigs, apiToken, apiUrl);

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,20 +1,21 @@
 import { PushPayload } from "./types";
 
-export function generateMessage(payload: PushPayload): string {
+export function generateMessage(payload: PushPayload, refName: string): string {
   const commits = payload.commits.map(
     (e) =>
       `
-  - Autore: ${e.author.name}
-    Data Creazione: ${e.timestamp}
-    Messaggio: ${e.message}
-    URL: ${e.url}`,
+  - Autore: __${e.author.name}__
+    Data Creazione: ${new Date(e.timestamp).toLocaleString()}
+    Messaggio: "**${e.message}**"
+    URL: ${e.url}`
   );
 
   let message = `
-  Nuovo push ${payload.forced ? "FORZATO" : ""} da parte di ${payload.pusher.name}:
-  
-  Commits:
-    ${commits.join("\n")}`;
+  💥 **Nuovo push ${payload.forced ? "(FORZATO ⚠️) " : ""}da parte di**:  __${payload.pusher.name}__:
+
+${refName != "" ? `**🪾 Branch**: \`\`\`${refName}\`\`\`\n` : ""}: 
+**📄 Commits**:
+  ${commits.join("\n")}`;
 
   return message;
 }


### PR DESCRIPTION
Better formatting and use of bold, italic and monospace strings. Also add 'refName' as parameter to pass the name of the branch involved in the push.